### PR TITLE
Use CircleCI instead of Travis CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,9 +1,11 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
-^data-raw$
+^\.circleci$
 ^appveyor\.yml$
 ^cran-comments\.md$
 ^README\.Rmd$
 ^README-.*\.png$
 ^update_KSJShapeProperty.R$
+^data-raw$
+^docs$

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,4 +20,4 @@ jobs:
        - run: Rscript -e "message(devtools::check_failures(path = '${RCHECK_DIR}'))"
 
        - store_artifacts:
-           path: {{ .Environment.RCHECK_DIR }}
+           path: "{{ .Environment.RCHECK_DIR }}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
 
        - run: Rscript -e "message(devtools::check_failures(path = '${RCHECK_DIR}'))"
 
+       - run:
+           command: mv ${RCHECK_DIR} /tmp/Rcheck
+           when: always
        - store_artifacts:
-           path: ${RCHECK_DIR}
-           when: "always"
+           path: /tmp/Rcheck
+           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
        - image: rocker/geospatial:latest
      steps:
        - checkout
-       - run: echo "hello world"
+       - run: Rscript -e "devtools::check()"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,6 @@ jobs:
        - run: R CMD check "${PKG_TARBALL}" --as-cran --no-manual
 
        - run: Rscript -e "message(devtools::check_failures(path = '${RCHECK_DIR}'))"
+
+       - store_artifacts:
+           path: {{ .Environment.RCHECK_DIR }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: rocker/geospatial:latest
+     steps:
+       - checkout
+       - run: echo "hello world"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,5 +20,5 @@ jobs:
        - run: Rscript -e "message(devtools::check_failures(path = '${RCHECK_DIR}'))"
 
        - store_artifacts:
-           path: "{{ .Environment.RCHECK_DIR }}"
+           path: ${RCHECK_DIR}
            when: "always"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,3 +21,4 @@ jobs:
 
        - store_artifacts:
            path: "{{ .Environment.RCHECK_DIR }}"
+           when: "always"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,5 +5,16 @@ jobs:
        - image: rocker/geospatial:latest
      steps:
        - checkout
+
        - run: R CMD build .
-       - run: R CMD check "kokudosuuchi_0.3.0.9000.tar.gz" --as-cran --no-manual
+
+       - run: |
+           Rscript --vanilla \
+             -e 'dsc <- read.dcf("DESCRIPTION")' \
+             -e 'sprintf("export PKG_TARBALL=%s_%s.tar.gz\n", dsc[,"Package"], dsc[,"Version"])' \
+             -e 'sprintf("export RCHECK_DIR=%s.Rcheck\n", dsc[,"Package"])' \
+             >> ${BASH_ENV}
+
+       - run: R CMD check "${PKG_TARBALL}" --as-cran --no-manual
+
+       - run: Rscript -e "message(devtools::check_failures(path = '${RCHECK_DIR}'))"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ jobs:
        - run: |
            Rscript --vanilla \
              -e 'dsc <- read.dcf("DESCRIPTION")' \
-             -e 'sprintf("export PKG_TARBALL=%s_%s.tar.gz\n", dsc[,"Package"], dsc[,"Version"])' \
-             -e 'sprintf("export RCHECK_DIR=%s.Rcheck\n", dsc[,"Package"])' \
+             -e 'cat(sprintf("export PKG_TARBALL=%s_%s.tar.gz\n", dsc[,"Package"], dsc[,"Version"]))' \
+             -e 'cat(sprintf("export RCHECK_DIR=%s.Rcheck\n", dsc[,"Package"]))' \
              >> ${BASH_ENV}
 
        - run: R CMD check "${PKG_TARBALL}" --as-cran --no-manual

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,5 @@ jobs:
        - image: rocker/geospatial:latest
      steps:
        - checkout
-       - run: Rscript -e "devtools::check()"
+       - run: R CMD build .
+       - run: R CMD check "kokudosuuchi_0.3.0.9000.tar.gz" --as-cran --no-manual

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-
-language: R
-sudo: false
-cache: packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     tools,
     shiny,
     stringi,
+    tibble,
     xml2
 LazyData: TRUE
 RoxygenNote: 6.0.1.9000

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 kokudosuuchi
 ============
 
-[![Travis-CI Build Status](https://travis-ci.org/yutannihilation/kokudosuuchi.svg?branch=master)](https://travis-ci.org/yutannihilation/kokudosuuchi) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/yutannihilation/kokudosuuchi?branch=master&svg=true)](https://ci.appveyor.com/project/yutannihilation/kokudosuuchi) [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/kokudosuuchi)](https://cran.r-project.org/package=kokudosuuchi)
+
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/yutannihilation/kokudosuuchi?branch=master&svg=true)](https://ci.appveyor.com/project/yutannihilation/kokudosuuchi)
+[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/kokudosuuchi)](https://cran.r-project.org/package=kokudosuuchi)
 
 **(Sorry, English version of README is not availavle for now.)**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 kokudosuuchi
 ============
 
-
+[![CircleCI](https://circleci.com/gh/yutannihilation/kokudosuuchi.svg?style=svg)](https://circleci.com/gh/yutannihilation/kokudosuuchi)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/yutannihilation/kokudosuuchi?branch=master&svg=true)](https://ci.appveyor.com/project/yutannihilation/kokudosuuchi)
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/kokudosuuchi)](https://cran.r-project.org/package=kokudosuuchi)
 

--- a/tests/testthat/test-getData.R
+++ b/tests/testthat/test-getData.R
@@ -11,8 +11,10 @@ test_that("getKSJData works", {
 verify_p12_14_06_gml <- function(d) {
   expect_equal(length(d), 3)
   purrr::walk(d, expect_s3_class, class = "sf")
-  expect_equal(unname(purrr::map_int(d, nrow)), c(10L, 1L, 2L))
-  expect_equal(names(d), c("P12a-14_06", "P12b-14_06", "P12c-14_06"))
+  expect_equal(sort(unname(purrr::map_int(d, nrow))),
+               sort(c(10L, 1L, 2L)))
+  expect_equal(sort(names(d)),
+               sort(c("P12a-14_06", "P12b-14_06", "P12c-14_06")))
 }
 
 test_that("getKSJData with UTF-8 layers works", {


### PR DESCRIPTION
Travis CI is great for testing most R packages, as long as the package doesn't need `sudo`. But those depends `sf` doesn't fit; it needs compilation until Ubuntu gets 16.10+ for the latest GDAL.

CircleCI can use any Docker images. Let's use `rocker/geospatial`.