### PR TITLE
Download atomicly

### DIFF
--- a/R/getKSJData.R
+++ b/R/getKSJData.R
@@ -104,7 +104,9 @@ download_KSJ_zip <- function(zip_url, cache_dir) {
   if (file.exists(zip_file)) {
     message(glue::glue("Using the cached zip file: {zip_file}"))
   } else {
-    curl::curl_download(zip_url, destfile = zip_file)
+    tmp_zip_file <- tempfile(fileext = ".zip")
+    curl::curl_download(zip_url, destfile = tmp_zip_file)
+    file.rename(tmp_zip_file, zip_file)
   }
 
   zip_file


### PR DESCRIPTION
When `curl::curl_download()` fails, `getKSJData()` uses the broken ZIP file and never succeeds. It is safer to rename after download.